### PR TITLE
Correct path to init_grid tracking files

### DIFF
--- a/deployment/init_grid/cloudformation/Makefile
+++ b/deployment/init_grid/cloudformation/Makefile
@@ -49,4 +49,5 @@ delete: clean-$(IAC_TOOL)
 	aws cloudformation wait stack-delete-complete --stack-name $(shell aws cloudformation describe-stacks --region $(REGION) --stack-name $(TAG) --query 'Stacks[0].StackId' --output text) --region $(REGION)
 
 clean:
-	rm -rf $(BUILD_DIR)/tag.*
+	rm -rf $(BUILD_DIR)/grid_init/tag.*
+	rm -rf $(BUILD_DIR)/grid_init/init-grid-*


### PR DESCRIPTION
### Description

If a user has only performed

```bash
$ make init-grid-state  TAG=$TAG REGION=$HTCGRID_REGION
```

then executing

```bash
$ make delete-grid-state TAG=$TAG REGION=$HTCGRID_REGION
$ make clean-grid-state TAG=$TAG REGION=$HTCGRID_REGION
```

will not delete the files in
`~/deployment/init_grid/cloudformation/.build/grid_init/` because `grid_init` is
missing from the path.

But with this change, users can execute

```bash
$ make init-grid-state  TAG=$TAG REGION=$HTCGRID_REGION
$ make delete-grid-state TAG=$TAG REGION=$HTCGRID_REGION
$ make clean-grid-state TAG=$TAG REGION=$HTCGRID_REGION
```

cyclically without needing to manually delete those files before starting over.

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
