### PR TITLE
Kubernetes Components Update and Code Cleanup

### DIFF
--- a/deployment/dev_environment_cloud9/cfn/cloud9-htc-grid.yaml
+++ b/deployment/dev_environment_cloud9/cfn/cloud9-htc-grid.yaml
@@ -30,7 +30,7 @@ Parameters:
   C9KubectlVersion:
     Description: kubectl version to install on Cloud9
     Type: String
-    Default: 1.25.12
+    Default: 1.31.4
     ConstraintDescription: Must be a valid kubectl version.
   C9TerraformVersion:
     Description: Terraform version to install on Cloud9

--- a/deployment/grid/terraform/variables.tf
+++ b/deployment/grid/terraform/variables.tf
@@ -33,13 +33,13 @@ variable "lambda_runtime" {
 variable "kubernetes_version" {
   description = "Name of EKS cluster in AWS"
   type        = string
-  default     = "1.25"
+  default     = "1.31"
 }
 
 variable "k8s_ca_version" {
   description = "Cluster autoscaler version"
   type        = string
-  default     = "v1.21.0"
+  default     = "v1.31.0"
 }
 
 variable "k8s_keda_version" {

--- a/source/compute_plane/python/agent/agent.py
+++ b/source/compute_plane/python/agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Amazon.com, Inc. or its affiliates. 
+# Copyright 2024 Amazon.com, Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 https://aws.amazon.com/apache-2-0/
 
@@ -638,7 +638,6 @@ async def run_task(task, sqs_msg):
     task_def = json.loads(tast_str)
 
     submit_pre_agent_measurements(task)
-    task_id = task["task_id"]
 
     xray_recorder.end_subsegment()
     execution_is_completed_flag = 0


### PR DESCRIPTION
### Description


This PR contains two main changes:

#### 1. Kubernetes Components Version Update
Updates the following components to their latest versions:
- kubectl: 1.25.12 -> 1.31.4
- EKS cluster: 1.25 -> 1.31
- Cluster Autoscaler: v1.21.0 -> v1.31.0

#### 2. Agent Code Cleanup for flake8 validation
- Removes unused `task_id` variable in run_task function
- Removes trailing whitespace in copyright header

### Checklist
- [ ] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes
- [ ] (Core team) Added labels for change area (e.g. `area/controlplane`) and kind (e.g. `kind/improvement`)

### BONUS POINTS checklist:
- [ ] Backfilled missing tests for code in same general area
- [ ] Refactored something and made the world a better place
